### PR TITLE
Bugfixes

### DIFF
--- a/polyglot.sh
+++ b/polyglot.sh
@@ -111,7 +111,7 @@ _branch_status() {
 _branch_changes() {
   [ -n "$ZSH_VERSION" ] && setopt NO_WARN_CREATE_GLOBAL
 
-  git_status=$(git status 2>&1)
+  git_status=$(LC_ALL=C git status 2>&1)
 
   symbols=''
 

--- a/polyglot.sh
+++ b/polyglot.sh
@@ -62,6 +62,7 @@ _is_ssh() {
       0)
         case $(ps -o comm= -p $PPID) in
           sshd|*/sshd) return 0 ;;
+          *) return 1 ;;
         esac
         ;;
       *) return 1 ;;


### PR DESCRIPTION
This pull request fixes two bugs I encountered after cloning the project.

1. If you're running a root shell (that is, `$EUID` equals 0),
```
case $EUID in
      0)
        case $(ps -o comm= -p $PPID) in
          sshd|*/sshd) return 0 ;;
        esac
        ;;
```
will return 0, although the current shell is not an ssh shell at all! My first commit fixes this.

Secondly, the `_branch_changes()` relies on git's output. This does not work, however, if git's default language is not English. Setting `LC_ALL=C` before the git command fixes this.