### PR TITLE
zsh fix for Bug #12  that did not reset vi insert or command mode status

### DIFF
--- a/polyglot.sh
+++ b/polyglot.sh
@@ -460,6 +460,7 @@ if [ -n "$ZSH_VERSION" ] && [ "${0#-}" != 'ksh' ] &&
 
   zle -N _polyglot_zle_keymap_select
   zle -A _polyglot_zle_keymap_select zle-keymap-select
+  zle -A _polyglot_zle_keymap_select zle-line-init
 
   ###########################################################
   # Redraw prompt when terminal size changes


### PR DESCRIPTION
I did some research and found I think the simplest way is to just add _polyglot_zle_keymap_select to the special widget zle-line-init so that the line is updated any time we get a new prompt.